### PR TITLE
chore: upstream=6.4.0,add=alpine_3.24,debian_forky,ubuntu_questing,drop=debian_bookworm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# bradfordwagner.ansible-role-docker-buildkit
+
+## Updating the version
+
+Version is controlled by `bk_ver` in `defaults/main.yml`.
+
+Check for the latest release at: https://github.com/moby/buildkit/releases
+
+```yaml
+bk_ver: vX.Y.Z
+```

--- a/config.yaml
+++ b/config.yaml
@@ -9,22 +9,26 @@ builds:
       archs:
         - linux/amd64
         - linux/arm64
+    - os: alpine_3.24
+      archs:
+        - linux/amd64
+        - linux/arm64
     - os: archlinux_latest
       archs:
         - linux/amd64
-    - os: debian_bookworm
-      archs:
-        - linux/amd64
-        - linux/arm64
-    - os: debian_bookworm-slim
-      archs:
-        - linux/amd64
-        - linux/arm64
     - os: debian_trixie
       archs:
         - linux/amd64
         - linux/arm64
     - os: debian_trixie-slim
+      archs:
+        - linux/amd64
+        - linux/arm64
+    - os: debian_forky
+      archs:
+        - linux/amd64
+        - linux/arm64
+    - os: debian_forky-slim
       archs:
         - linux/amd64
         - linux/arm64
@@ -36,6 +40,10 @@ builds:
       archs:
         - linux/amd64
         - linux/arm64
+    - os: ubuntu_questing
+      archs:
+        - linux/amd64
+        - linux/arm64
 upstream:
     repo: ghcr.io/bradfordwagner/ansible
-    tag: 6.3.1
+    tag: 6.4.0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-bk_ver: v0.19.0
+bk_ver: v0.31.1
 bk_mirror: https://github.com/moby/buildkit/releases/download
 bk_timeout_seconds: 300
 bk_secure: true


### PR DESCRIPTION
## Summary
- Bump ansible upstream tag 6.3.1 -> 6.4.0
- Add alpine_3.24, debian_forky, debian_forky-slim, ubuntu_questing
- Drop debian_bookworm, debian_bookworm-slim (Python 3.11 incompatible with Ansible 14)